### PR TITLE
[chore] API 구현에 참여하지 않는 인원 CODEOWNERS에서 제거

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @05AM @hyunkkkk @Yuurim98
+* @05AM @hyunkkkk @YuGyeong98

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @05AM @GiYeons @hyunkkkk @YuGyeong98 @Yuurim98
+* @05AM @hyunkkkk @Yuurim98


### PR DESCRIPTION
## 🔥 구현 기능
> API 서버 구현에 참여하지 않는 인원을 CODEOWNERS에서 제거

리뷰 요청이 가는 것을 막기 위해 API 서버 구현에 참여하지 않는 인원을 현재 레포지터리의 CODEOWNERS에서 제거했습니다.
