### PR TITLE
#7 [feat] 좌표계 변환 유틸리티 클래스 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,62 +1,66 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.3.2'
-	id 'io.spring.dependency-management' version '1.1.6'
+    id 'java'
+    id 'org.springframework.boot' version '3.3.2'
+    id 'io.spring.dependency-management' version '1.1.6'
 }
 
 group = 'com.tenten'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
 
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 
-	// DB
-	implementation 'org.flywaydb:flyway-core'
-	implementation 'org.flywaydb:flyway-mysql'
-	runtimeOnly 'com.h2database:h2'
-	runtimeOnly 'com.mysql:mysql-connector-j'
+    // DB
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-mysql'
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
 
-	// QueryDsl
-	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
-	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
-	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    // QueryDsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
-	// API Docs
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+    // API Docs
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 
-	// JWT
-	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
-	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
-	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+    // Coordinate Convert
+    implementation 'org.locationtech.proj4j:proj4j:1.3.0'
+    implementation 'org.locationtech.proj4j:proj4j-epsg:1.3.0'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/com/tenten/eatmatjib/common/config/CoordinateConverterConfig.java
+++ b/src/main/java/com/tenten/eatmatjib/common/config/CoordinateConverterConfig.java
@@ -1,0 +1,25 @@
+package com.tenten.eatmatjib.common.config;
+
+import com.tenten.eatmatjib.common.util.CoordinateConverter;
+import org.locationtech.proj4j.CRSFactory;
+import org.locationtech.proj4j.CoordinateReferenceSystem;
+import org.locationtech.proj4j.CoordinateTransformFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CoordinateConverterConfig {
+    private static final String SOURCE_COORDINATE_SYSTEM = "epsg:4326";
+    private static final String TARGET_COORDINATE_SYSTEM = "epsg:2097";
+
+    @Bean
+    public CoordinateConverter coordinateConverter() {
+        CRSFactory factory = new CRSFactory();
+
+        CoordinateReferenceSystem source = factory.createFromName(SOURCE_COORDINATE_SYSTEM);
+        CoordinateReferenceSystem target = factory.createFromName(TARGET_COORDINATE_SYSTEM);
+
+        CoordinateTransformFactory ctFactory = new CoordinateTransformFactory();
+        return new CoordinateConverter(ctFactory.createTransform(source, target));
+    }
+}

--- a/src/main/java/com/tenten/eatmatjib/common/util/CoordinateConverter.java
+++ b/src/main/java/com/tenten/eatmatjib/common/util/CoordinateConverter.java
@@ -1,0 +1,20 @@
+package com.tenten.eatmatjib.common.util;
+
+import com.tenten.eatmatjib.member.domain.Coord;
+import org.locationtech.proj4j.CoordinateTransform;
+import org.locationtech.proj4j.ProjCoordinate;
+
+public class CoordinateConverter {
+    private final CoordinateTransform coordinateTransform;
+
+    public CoordinateConverter(CoordinateTransform coordinateTransform) {
+        this.coordinateTransform = coordinateTransform;
+    }
+
+    public Coord convert(Coord coord) {
+        ProjCoordinate result = new ProjCoordinate();
+        coordinateTransform.transform(new ProjCoordinate(coord.x(), coord.y()), result);
+
+        return new Coord(result.x, result.y);
+    }
+}

--- a/src/main/java/com/tenten/eatmatjib/common/util/CoordinateConverter.java
+++ b/src/main/java/com/tenten/eatmatjib/common/util/CoordinateConverter.java
@@ -1,15 +1,13 @@
 package com.tenten.eatmatjib.common.util;
 
 import com.tenten.eatmatjib.member.domain.Coord;
+import lombok.RequiredArgsConstructor;
 import org.locationtech.proj4j.CoordinateTransform;
 import org.locationtech.proj4j.ProjCoordinate;
 
+@RequiredArgsConstructor
 public class CoordinateConverter {
     private final CoordinateTransform coordinateTransform;
-
-    public CoordinateConverter(CoordinateTransform coordinateTransform) {
-        this.coordinateTransform = coordinateTransform;
-    }
 
     public Coord convert(Coord coord) {
         ProjCoordinate result = new ProjCoordinate();

--- a/src/main/java/com/tenten/eatmatjib/member/domain/Coord.java
+++ b/src/main/java/com/tenten/eatmatjib/member/domain/Coord.java
@@ -1,0 +1,7 @@
+package com.tenten.eatmatjib.member.domain;
+
+public record Coord(
+        double x,
+        double y
+) {
+}

--- a/src/test/java/com/tenten/eatmatjib/common/util/CoordinateConverterTest.java
+++ b/src/test/java/com/tenten/eatmatjib/common/util/CoordinateConverterTest.java
@@ -1,0 +1,44 @@
+package com.tenten.eatmatjib.common.util;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.tenten.eatmatjib.member.domain.Coord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@DisplayName("[단위 테스트] 좌표계 변환 정확도 테스트")
+@SpringBootTest
+@ExtendWith(MockitoExtension.class)
+class CoordinateConverterTest {
+
+    @Autowired
+    CoordinateConverter coordinateConverter;
+
+    @DisplayName("[성공] 좌표계의 원점 좌표 변환에 성공한다.")
+    @Test
+    void convert_origin_success() {
+        // given
+        Coord origin = getOriginGeographicCoords();
+        Coord expected = getOriginProjectedCoords();
+
+        // when
+        Coord actual = coordinateConverter.convert(origin);
+
+        //then
+        double delta = 0.1;     // 허용 오차 (미터 단위)
+        assertThat(actual.x()).isCloseTo(expected.x(), within(delta));
+        assertThat(actual.y()).isCloseTo(expected.y(), within(delta));
+    }
+
+    private Coord getOriginGeographicCoords() {
+        return new Coord(127.0, 38.0);
+    }
+
+    private Coord getOriginProjectedCoords() {
+        return new Coord(200000.0, 500000.0);
+    }
+}


### PR DESCRIPTION
## 🔥 구현 기능
> 위도 경도 좌표계인 EPSG:4326에서 중부원점좌표계(EPSG:2097)로 변환하는 좌표계 변환 유틸리티 클래스 구현

## 🔥 구현 방법
- proj4j 라이브러리 의존성 추가
- CoordinateConverterConfig 설정
- member 도메인에 좌표 값 클래스 Coord 구현
- util 패키지에 CoordinateConverter 구현

## 🔥 관련 이슈
related: #7
 
## 🔥 전달 사항
https://epsg.io/transform#s_srs=2097&t_srs=4326

위 사이트에서 변환 정확도를 테스트해봤는데 사이트 변환 결과가 구글 맵과 비교하여 일치하지 않았습니다.
그래서 사이트 변환 로직의 신빙성이 증명되지 않아 나중에 추가로 구글 맵과 병행하여 정확도 테스트를 진행할 예정입니다.

혹시나 라이브러리를 바꾸게 되어도 지금 메서드 형식과 다름이 없을 것으로, 기능 구현하실 때 사용해주시면 좋을 것 같습니다.

테스트 결과에 대해서는 추후 진행하고 공유하겠습니다.

## 🔥 참고 할만한 자료(선택)
관련 이슈에도 공유한 내용이지만 재공유합니다.

- proj4j
https://github.com/locationtech/proj4j

- 서울시 일반음식점 인허가 정보
https://data.seoul.go.kr/dataList/OA-16094/S/1/datasetView.do