### PR TITLE
[feat] 사용자 정보 API

### DIFF
--- a/src/main/java/com/tenten/eatmatjib/common/config/auth/AuthUserResolver.java
+++ b/src/main/java/com/tenten/eatmatjib/common/config/auth/AuthUserResolver.java
@@ -1,9 +1,9 @@
 package com.tenten.eatmatjib.common.config.auth;
 
-import static com.tenten.eatmatjib.common.exception.ErrorCode.*;
+import static com.tenten.eatmatjib.common.exception.ErrorCode.INVALID_TOKEN_UNAUTHORIZED;
+import static com.tenten.eatmatjib.common.exception.ErrorCode.LOGIN_UNAUTHORIZED;
 
 import com.tenten.eatmatjib.common.exception.BusinessException;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
@@ -21,14 +21,14 @@ public class AuthUserResolver implements HandlerMethodArgumentResolver {
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
         boolean hasAnnotation = parameter.hasParameterAnnotation(AuthUser.class);
-        boolean isString = parameter.getParameterType().equals(String.class);
+        boolean isLong = parameter.getParameterType().equals(Long.class);
 
-        return hasAnnotation && isString;
+        return hasAnnotation && isLong;
     }
 
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
-            NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
         String bearerToken = webRequest.getHeader("Authorization");
 
         if (bearerToken == null || bearerToken.isEmpty()) {
@@ -40,8 +40,6 @@ public class AuthUserResolver implements HandlerMethodArgumentResolver {
             throw new BusinessException(INVALID_TOKEN_UNAUTHORIZED);
         }
 
-        String memberId = jwtUtil.getMemberId(token);
-
-        return memberId;
+        return jwtUtil.getMemberId(token);
     }
 }

--- a/src/main/java/com/tenten/eatmatjib/common/config/auth/JwtUtil.java
+++ b/src/main/java/com/tenten/eatmatjib/common/config/auth/JwtUtil.java
@@ -79,8 +79,8 @@ public class JwtUtil {
         return false;
     }
 
-    public String getMemberId(String token) {
-        return parseClaims(token).get("id", String.class);
+    public Long getMemberId(String token) {
+        return parseClaims(token).get("id", Long.class);
     }
 
     public Claims parseClaims(String token) {

--- a/src/main/java/com/tenten/eatmatjib/common/exception/ErrorCode.java
+++ b/src/main/java/com/tenten/eatmatjib/common/exception/ErrorCode.java
@@ -26,6 +26,11 @@ public enum ErrorCode {
     INVALID_TOKEN_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
 
     /**
+     * 404 Not Found
+     */
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 멤버입니다."),
+
+    /**
      * 409 - Conflict
      */
     ACCOUNT_CONFLICT(HttpStatus.CONFLICT, "이미 사용중인 계정입니다."),

--- a/src/main/java/com/tenten/eatmatjib/member/controller/MemberController.java
+++ b/src/main/java/com/tenten/eatmatjib/member/controller/MemberController.java
@@ -2,14 +2,18 @@ package com.tenten.eatmatjib.member.controller;
 
 import static org.springframework.http.HttpStatus.CREATED;
 
+import com.tenten.eatmatjib.common.config.auth.AuthUser;
 import com.tenten.eatmatjib.common.exception.ErrorResponse;
 import com.tenten.eatmatjib.member.controller.request.LoginMemberReq;
 import com.tenten.eatmatjib.member.controller.request.RegisterMemberReq;
+import com.tenten.eatmatjib.member.controller.response.InfoMemberRes;
 import com.tenten.eatmatjib.member.controller.response.LoginMemberRes;
 import com.tenten.eatmatjib.member.controller.response.RegisterMemberRes;
+import com.tenten.eatmatjib.member.service.MemberInfoService;
 import com.tenten.eatmatjib.member.service.MemberLoginService;
 import com.tenten.eatmatjib.member.service.MemberRegisterService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -19,6 +23,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -33,6 +38,7 @@ public class MemberController {
 
     private final MemberRegisterService memberRegisterService;
     private final MemberLoginService memberLoginService;
+    private final MemberInfoService memberInfoService;
 
     @PostMapping("/register")
     @Operation(summary = "사용자 회원가입")
@@ -63,6 +69,21 @@ public class MemberController {
     })
     public ResponseEntity<LoginMemberRes> login(@RequestBody @Valid LoginMemberReq request) {
         LoginMemberRes response = memberLoginService.execute(request);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/info")
+    @Operation(summary = "사용자 정보 조회")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "사용자 정보 조회 성공"),
+        @ApiResponse(
+            responseCode = "404",
+            description = "존재하지 않는 멤버입니다.",
+            content = {@Content(schema = @Schema(implementation = ErrorResponse.class))}
+        )
+    })
+    public ResponseEntity<InfoMemberRes> info(@Parameter(hidden = true) @AuthUser Long memberId) {
+        InfoMemberRes response = memberInfoService.execute(memberId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/tenten/eatmatjib/member/controller/response/InfoMemberRes.java
+++ b/src/main/java/com/tenten/eatmatjib/member/controller/response/InfoMemberRes.java
@@ -1,0 +1,43 @@
+package com.tenten.eatmatjib.member.controller.response;
+
+import com.tenten.eatmatjib.member.domain.Member;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Schema(description = "사용자 정보 응답 객체")
+@Getter
+@Builder
+public class InfoMemberRes {
+
+    @Schema(description = "사용자 id", example = "1")
+    private Long id;
+
+    @Schema(description = "사용자 계정", example = "tenten")
+    private String account;
+
+    @Schema(description = "사용자 x좌표", example = "200000.1234567891")
+    private BigDecimal x;
+
+    @Schema(description = "사용자 y좌표", example = "200000.1234567891")
+    private BigDecimal y;
+
+    @Schema(description = "사용자 점심 추천 기능 사용 여부", example = "true")
+    private Boolean isRecommendationActive;
+
+    @Schema(description = "사용자 가입 날짜")
+    private LocalDateTime joinedAt;
+
+    public static InfoMemberRes of(Member member) {
+        return InfoMemberRes.builder()
+            .id(member.getId())
+            .account(member.getAccount())
+            .x(member.getX())
+            .y(member.getY())
+            .isRecommendationActive(member.getIsRecommendationActive())
+            .joinedAt(member.getJoinedAt())
+            .build();
+    }
+}

--- a/src/main/java/com/tenten/eatmatjib/member/controller/response/InfoMemberRes.java
+++ b/src/main/java/com/tenten/eatmatjib/member/controller/response/InfoMemberRes.java
@@ -1,9 +1,10 @@
 package com.tenten.eatmatjib.member.controller.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.tenten.eatmatjib.member.domain.Member;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -27,8 +28,9 @@ public class InfoMemberRes {
     @Schema(description = "사용자 점심 추천 기능 사용 여부", example = "true")
     private Boolean isRecommendationActive;
 
-    @Schema(description = "사용자 가입 날짜")
-    private LocalDateTime joinedAt;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    @Schema(description = "사용자 가입 날짜", example = "2024-08-31")
+    private LocalDate joinedAt;
 
     public static InfoMemberRes of(Member member) {
         return InfoMemberRes.builder()
@@ -37,7 +39,7 @@ public class InfoMemberRes {
             .x(member.getX())
             .y(member.getY())
             .isRecommendationActive(member.getIsRecommendationActive())
-            .joinedAt(member.getJoinedAt())
+            .joinedAt(LocalDate.from(member.getJoinedAt()))
             .build();
     }
 }

--- a/src/main/java/com/tenten/eatmatjib/member/service/MemberInfoService.java
+++ b/src/main/java/com/tenten/eatmatjib/member/service/MemberInfoService.java
@@ -1,0 +1,24 @@
+package com.tenten.eatmatjib.member.service;
+
+import static com.tenten.eatmatjib.common.exception.ErrorCode.MEMBER_NOT_FOUND;
+
+import com.tenten.eatmatjib.common.exception.BusinessException;
+import com.tenten.eatmatjib.member.controller.response.InfoMemberRes;
+import com.tenten.eatmatjib.member.domain.Member;
+import com.tenten.eatmatjib.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberInfoService {
+
+    private final MemberRepository memberRepository;
+
+    public InfoMemberRes execute(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND));
+
+        return InfoMemberRes.of(member);
+    }
+}

--- a/src/test/java/com/tenten/eatmatjib/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/tenten/eatmatjib/member/controller/MemberControllerTest.java
@@ -2,10 +2,12 @@ package com.tenten.eatmatjib.member.controller;
 
 import static com.tenten.eatmatjib.common.exception.ErrorCode.ACCOUNT_CONFLICT;
 import static com.tenten.eatmatjib.common.exception.ErrorCode.ACCOUNT_UNAUTHORIZED;
+import static com.tenten.eatmatjib.common.exception.ErrorCode.MEMBER_NOT_FOUND;
 import static com.tenten.eatmatjib.common.exception.ErrorCode.PASSWORD_UNAUTHORIZED;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -18,9 +20,11 @@ import com.tenten.eatmatjib.common.exception.BusinessException;
 import com.tenten.eatmatjib.common.exception.GlobalExceptionHandler;
 import com.tenten.eatmatjib.member.controller.request.LoginMemberReq;
 import com.tenten.eatmatjib.member.controller.request.RegisterMemberReq;
+import com.tenten.eatmatjib.member.controller.response.InfoMemberRes;
 import com.tenten.eatmatjib.member.controller.response.LoginMemberRes;
 import com.tenten.eatmatjib.member.controller.response.RegisterMemberRes;
 import com.tenten.eatmatjib.member.domain.Member;
+import com.tenten.eatmatjib.member.service.MemberInfoService;
 import com.tenten.eatmatjib.member.service.MemberLoginService;
 import com.tenten.eatmatjib.member.service.MemberRegisterService;
 import java.time.LocalDateTime;
@@ -42,6 +46,9 @@ class MemberControllerTest {
 
     @Mock
     private MemberLoginService memberLoginService;
+
+    @Mock
+    private MemberInfoService memberInfoService;
 
     @InjectMocks
     private MemberController memberController;
@@ -165,6 +172,50 @@ class MemberControllerTest {
         // then
         resultActions.andExpect(status().isUnauthorized())
             .andExpect(jsonPath("$.message").value("비밀번호를 잘못 입력했습니다."));
+    }
+
+    @DisplayName("사용자 정보 조회를 성공하면 200을 반환한다.")
+    @Test
+    public void memberInfoSuccessReturn200() throws Exception {
+        // given
+        InfoMemberRes response = InfoMemberRes.of(getMember());
+
+        when(memberInfoService.execute(any())).thenReturn(response);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+            get("/api/v1/members/info")
+                .contentType(APPLICATION_JSON)
+        );
+
+        // then
+        resultActions.andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(response.getId()))
+            .andExpect(jsonPath("$.account").value(response.getAccount()))
+            .andExpect(jsonPath("$.x").value(response.getX()))
+            .andExpect(jsonPath("$.y").value(response.getY()))
+            .andExpect(
+                jsonPath("$.isRecommendationActive").value(response.getIsRecommendationActive())
+            ).andExpect(
+                jsonPath("$.joinedAt").value(response.getJoinedAt().toString())
+            );
+    }
+
+    @DisplayName("존재하지 않는 id로 사용자 정보 조회를 하면 404를 반환한다.")
+    @Test
+    void notFoundMemberInfoReturn404() throws Exception {
+        // given
+        when(memberInfoService.execute(any())).thenThrow(new BusinessException(MEMBER_NOT_FOUND));
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+            get("/api/v1/members/info")
+                .contentType(APPLICATION_JSON)
+        );
+
+        // then
+        resultActions.andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.message").value("존재하지 않는 멤버입니다."));
     }
 
     private RegisterMemberReq getRegisterMemberReq() {

--- a/src/test/java/com/tenten/eatmatjib/member/service/MemberInfoServiceTest.java
+++ b/src/test/java/com/tenten/eatmatjib/member/service/MemberInfoServiceTest.java
@@ -1,0 +1,72 @@
+package com.tenten.eatmatjib.member.service;
+
+import static com.tenten.eatmatjib.common.exception.ErrorCode.MEMBER_NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.tenten.eatmatjib.common.exception.BusinessException;
+import com.tenten.eatmatjib.member.controller.response.InfoMemberRes;
+import com.tenten.eatmatjib.member.domain.Member;
+import com.tenten.eatmatjib.member.repository.MemberRepository;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MemberInfoServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private MemberInfoService memberInfoService;
+
+    @DisplayName("사용자 정보 조회를 하면 사용자 정보 응답 객체를 반환한다.")
+    @Test
+    void memberInfoReturnInfoMemberRes() {
+        // given
+        Long memberId = 1L;
+        Member member = getMember();
+        InfoMemberRes response = InfoMemberRes.of(getMember());
+
+        when(memberRepository.findById(any())).thenReturn(Optional.ofNullable(member));
+
+        // when
+        InfoMemberRes result = memberInfoService.execute(memberId);
+
+        // then
+        assertThat(result.getId()).isEqualTo(response.getId());
+    }
+
+    @DisplayName("존재하지 않는 id로 사용자 정보 조회를 하면 예외가 발생한다.")
+    @Test
+    void notFoundMemberInfoThrowsException() {
+        // given
+        Long memberId = 1L;
+
+        when(memberRepository.findById(any())).thenReturn(Optional.empty());
+
+        // when
+        BusinessException exception = assertThrows(BusinessException.class,
+            () -> memberInfoService.execute(memberId)
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(MEMBER_NOT_FOUND);
+    }
+
+    private Member getMember() {
+        return Member.builder()
+            .account("tenten")
+            .password("password12!")
+            .joinedAt(LocalDateTime.now())
+            .build();
+    }
+}


### PR DESCRIPTION
## 🔥 구현 기능
> 비밀번호를 제외한 모든 사용자 정보를 반환하는 사용자 정보 API를 구현하였습니다.

## 🔥 구현 방법
- 현재 member 엔티티에서 id가 Long 타입이기 때문에, Jwt 관련 클래스에서 String으로 반환되던 member id를 Long으로 변경하였습니다.
- AuthUser 어노테이션을 사용하여 memberId를 받아 멤버가 DB에 존재하는지 확인하여, 없으면 '존재하지 않는 멤버입니다.' 라는 404 Not Found 에러를 발생시켰습니다.
- 사용자 정보 조회가 성공하면 200 상태코드 + 사용자 정보(id, 계정, x, y 좌표, 점심 추천 기능 사용 여부, 가입 날짜)가 반환되도록 하였습니다.
- 컨트롤러, 서비스 테스트 코드를 작성하였습니다.

## 🔥 관련 이슈
related: #9 
    
## 참고 할만한 자료(선택)
