### PR TITLE
 #3 [fix] 리뷰 컨트롤러 테스트 실패 에러 해결

### DIFF
--- a/src/main/java/com/tenten/eatmatjib/review/dto/ReviewRequest.java
+++ b/src/main/java/com/tenten/eatmatjib/review/dto/ReviewRequest.java
@@ -1,11 +1,12 @@
 package com.tenten.eatmatjib.review.dto;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
+@EqualsAndHashCode
 public class ReviewRequest {
-
 
     private String content; // 리뷰 내용
     private int score;      // 평점

--- a/src/test/java/com/tenten/eatmatjib/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/tenten/eatmatjib/review/controller/ReviewControllerTest.java
@@ -3,6 +3,7 @@ package com.tenten.eatmatjib.review.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tenten.eatmatjib.common.exception.BusinessException;
 import com.tenten.eatmatjib.common.exception.ErrorCode;
+import com.tenten.eatmatjib.common.exception.GlobalExceptionHandler;
 import com.tenten.eatmatjib.review.dto.ReviewRequest;
 import com.tenten.eatmatjib.review.service.AddReviewService;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,6 +17,7 @@ import org.springframework.http.converter.json.MappingJackson2HttpMessageConvert
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.filter.CharacterEncodingFilter;
+
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -39,7 +41,9 @@ class ReviewControllerTest {
     void setUp() {
         MockitoAnnotations.openMocks(this);
         mockMvc = MockMvcBuilders.standaloneSetup(reviewController)
-                .setMessageConverters(new MappingJackson2HttpMessageConverter()) // Jackson converter 추가
+                .setControllerAdvice(GlobalExceptionHandler.class)
+                .setMessageConverters(
+                        new MappingJackson2HttpMessageConverter()) // Jackson converter 추가
                 .addFilters(new CharacterEncodingFilter("UTF-8", true))
                 .build();
     }
@@ -109,7 +113,4 @@ class ReviewControllerTest {
                         .content(new ObjectMapper().writeValueAsString(reviewRequest)))
                 .andExpect(status().isNotFound());
     }
-
-
 }
-


### PR DESCRIPTION
## 🔥 상세 에러
- ReviewRequest의 동일성을 보장하지 못해 에러 발생
- GlobalExceptionHandler 미설정으로 예외 catch 실패

## 🔥 구현 방법
- ReviewRequest에 lobok의 @EqualsAndHashCode 어노테이션을 추가해 동일성 검사
- MockMvcBuilders.standaloneSetup에서 setControllerAdvice로 전역적 에러 처리기를 명시

## 🔥 관련 이슈
related: #3
